### PR TITLE
Fail Start Hook If Insufficient RAM

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -75,14 +75,23 @@ if ['default', 'primary', 'secondary'].include? payload[:member][:role]
     owner 'gonano'
     group 'gonano'
   end
-  
+
   if payload[:platform] == 'local'
     maxmemory = 128
     appname   = 'nanobox'
   else
     total_mem = `vmstat -s | grep 'total memory' | awk '{print $1}'`.to_i
     cgroup_mem = `cat /sys/fs/cgroup/memory/memory.limit_in_bytes`.to_i
-    maxmemory = [ total_mem / 1024, cgroup_mem / 1024 / 1024 ].min
+    # Don't go above 80,000 MiB, because somewhere around 32 GiB is when the JVM
+    # switches from "compressed OOPs" to regular ones, which consume twice the
+    # space in RAM, and negatively impact performance. 80,000 * 0.4 == 32,000,
+    # which is safe.
+    # [https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html]
+    # We also don't want to go below 128 MiB, or ES will fail to start at all.
+    # The start hook will verify whether this amount of RAM is available before
+    # actually starting the service, so we can safely set it to that size here
+    # in the configuration hook.
+    maxmemory = [ [ total_mem / 1024, cgroup_mem / 1024 / 1024, 32000 ].min, 128 ].max
     appname   = 'nanobox'
   end
 
@@ -125,14 +134,14 @@ if ['default', 'primary', 'secondary'].include? payload[:member][:role]
     ["/var/log/gonano/db/current"].each do |log_file|
       if not ::File.exists? "#{log_file}"
         parent = File.expand_path("..", "#{log_file}")
-        
+
         # create the parent directory
         directory parent do
           owner 'gonano'
           group 'gonano'
           recursive true
         end
-        
+
         # create the log_file
         file "#{log_file}" do
           owner 'gonano'

--- a/src/start
+++ b/src/start
@@ -9,19 +9,14 @@ require 'hookit/setup'
 
 include Hooky::Elasticsearch
 
-if payload[:platform] == 'local'
-  maxmemory = 128
-else
-  total_mem = `vmstat -s | grep 'total memory' | awk '{print $1}'`.to_i
-  cgroup_mem = `cat /sys/fs/cgroup/memory/memory.limit_in_bytes`.to_i
-  maxmemory = [ total_mem / 1024, cgroup_mem / 1024 / 1024 ].min
-end
+needmemory = `grep '^-Xms' '/data/etc/elasticsearch/jvm.options' | sed 's/-Xms\\([0-9]\\+\\)m/\\1/'`.to_i
 
-freememory = `vmstat -s | grep 'free memory' | awk '{print $1}'`.to_i / 1024
-needmemory = maxmemory * 0.4
+free_mem = `vmstat -s | grep 'free memory' | awk '{print $1}'`.to_i
+cgroup_mem = `cat /sys/fs/cgroup/memory/memory.limit_in_bytes`.to_i - `cat /sys/fs/cgroup/memory/memory.usage_in_bytes`.to_i
+freememory = [ free_mem / 1024, cgroup_mem / 1024 / 1024 ].min
 
 if needmemory >= freememory
-  raise NoMemoryError, "Not enough RAM to start ElasticSearch. Have #{freememory}, but need #{maxmemory}. Try scaling up your server."
+  raise NoMemoryError, "Not enough RAM to start ElasticSearch. Have #{freememory} MiB, but need #{needmemory} MiB. Try scaling up your server."
 end
 
 # Import service (and start)

--- a/src/start
+++ b/src/start
@@ -9,6 +9,21 @@ require 'hookit/setup'
 
 include Hooky::Elasticsearch
 
+if payload[:platform] == 'local'
+  maxmemory = 128
+else
+  total_mem = `vmstat -s | grep 'total memory' | awk '{print $1}'`.to_i
+  cgroup_mem = `cat /sys/fs/cgroup/memory/memory.limit_in_bytes`.to_i
+  maxmemory = [ total_mem / 1024, cgroup_mem / 1024 / 1024 ].min
+end
+
+freememory = `vmstat -s | grep 'free memory' | awk '{print $1}'`.to_i / 1024
+needmemory = maxmemory * 0.4
+
+if needmemory >= freememory
+  raise NoMemoryError, "Not enough RAM to start ElasticSearch. Have #{freememory}, but need #{maxmemory}. Try scaling up your server."
+end
+
 # Import service (and start)
 directory '/etc/service/db' do
   recursive true

--- a/test/tests/simple-single-backup-restore.bats
+++ b/test/tests/simple-single-backup-restore.bats
@@ -10,10 +10,10 @@ echo_lines() {
 }
 
 @test "Start Container" {
-  start_container "backup-restore" "192.168.0.2"
+  start_container "backup-restore" "192.168.0.2" 512
   run run_hook "backup-restore" "configure" "$(payload configure)"
   echo_lines
-  [ "$status" -eq 0 ] 
+  [ "$status" -eq 0 ]
   run run_hook "backup-restore" "start" "$(payload start)"
   [ "$status" -eq 0 ]
   # Verify
@@ -23,7 +23,7 @@ echo_lines() {
 }
 
 @test "Start Backup Container" {
-  start_container "backup" "192.168.0.9"
+  start_container "backup" "192.168.0.9" 512
   # generate some keys
   run run_hook "backup" "configure" "$(payload configure)"
   echo_lines

--- a/test/tests/simple-single-low-ram.bats
+++ b/test/tests/simple-single-low-ram.bats
@@ -1,0 +1,31 @@
+# source docker helpers
+. util/docker.sh
+. util/service.sh
+
+echo_lines() {
+  for (( i=0; i < ${#lines[*]}; i++ ))
+  do
+    echo ${lines[$i]}
+  done
+}
+
+@test "Start Low RAM Container" {
+  start_container "simple-single-low-ram" "192.168.0.2" 64
+}
+
+@test "Configure Low RAM Container" {
+  run run_hook "simple-single-low-ram" "configure" "$(payload configure-local)"
+  echo_lines
+  [ "$status" -eq 0 ]
+}
+
+@test "Fail To Start Low RAM ${service_name}" {
+  run run_hook "simple-single-low-ram" "start" "$(payload start)"
+  echo_lines
+  [[ "$output" =~ "Not enough RAM" ]]
+  [ "$status" -ne 0 ]
+}
+
+@test "Stop Low RAM Container" {
+  stop_container "simple-single-low-ram"
+}

--- a/test/tests/simple-single.bats
+++ b/test/tests/simple-single.bats
@@ -10,13 +10,13 @@ echo_lines() {
 }
 
 @test "Start Production Container" {
-  start_container "simple-single-production" "192.168.0.2"
+  start_container "simple-single-production" "192.168.0.2" 512
 }
 
 @test "Configure Production Container" {
   run run_hook "simple-single-production" "configure" "$(payload configure)"
   echo_lines
-  [ "$status" -eq 0 ] 
+  [ "$status" -eq 0 ]
 }
 
 @test "Start Production ${service_name}" {
@@ -30,7 +30,7 @@ echo_lines() {
 
 @test "Verify IP" {
   run docker exec simple-single-production bash -c "ifconfig | grep 192.168.0.3"
-  [ "$status" -eq 0 ] 
+  [ "$status" -eq 0 ]
 }
 
 @test "Insert Production ${service_name} Data" {
@@ -52,7 +52,7 @@ echo_lines() {
 
 @test "Verify No IP" {
   run docker exec simple-single-production bash -c "ifconfig | grep 192.168.0.3"
-  [ "$status" -eq 1 ] 
+  [ "$status" -eq 1 ]
 }
 
 @test "Stop Production Container" {

--- a/test/util/docker.sh
+++ b/test/util/docker.sh
@@ -20,11 +20,12 @@ run_hook() {
 start_container() {
   name=$1
   ip=$2
+  ram=${3:-256}
 
   docker run \
     --name=$name \
     -d \
-    -m 512M \
+    -m ${ram}M \
     -e "PATH=$(path)" \
     --privileged \
     --net=nanobox \


### PR DESCRIPTION
We need a more informative error message if there isn't enough memory to spin up ES into. This commit adds one, ensuring the memory Java will attempt to allocate doesn't exceed the amount actually available at the time the hook runs.